### PR TITLE
back to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oxhttp"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
cause a error on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal compatibility settings to align with a more established standard for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->