### PR TITLE
fix: static_file handler on sende byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ router.route(protected)
 
 ```python
 router = Router()
-router.route(static_files("./static", "static"))
+router.route(static_file("./static", "static"))
 # Serves files from ./static directory at /static URL path
 ```
 

--- a/examples/main.py
+++ b/examples/main.py
@@ -9,7 +9,7 @@ from oxhttp import (
     Status,
     get,
     post,
-    static_files,
+    static_file,
 )
 
 
@@ -79,7 +79,7 @@ class AppData:
 
 pub_router = Router()
 pub_router.routes([hello_world, login, register, add])
-pub_router.route(static_files("./static", "static"))
+pub_router.route(static_file("./static", "static"))
 
 sec_router = Router()
 sec_router.route(user_info)

--- a/src/into_response.rs
+++ b/src/into_response.rs
@@ -13,7 +13,7 @@ impl IntoResponse for String {
         Ok(Response {
             status: Status::OK,
             headers: HashMap::from([("Content-Type".to_string(), "text/plain".to_string())]),
-            body: self.clone(),
+            body: self.clone().into_bytes(),
         })
     }
 }
@@ -23,7 +23,7 @@ impl IntoResponse for PyObject {
         Ok(Response {
             status: Status::OK,
             headers: HashMap::from([("Content-Type".to_string(), "application/json".to_string())]),
-            body: crate::json::dumps(self)?,
+            body: crate::json::dumps(self)?.into_bytes(),
         })
     }
 }
@@ -33,7 +33,7 @@ impl IntoResponse for (String, Status) {
         Ok(Response {
             status: self.1.clone(),
             headers: HashMap::from([("Content-Type".to_string(), "text/plain".to_string())]),
-            body: self.0.clone(),
+            body: self.0.clone().into_bytes(),
         })
     }
 }
@@ -43,7 +43,7 @@ impl IntoResponse for (PyObject, Status) {
         Ok(Response {
             status: self.1.clone(),
             headers: HashMap::from([("Content-Type".to_string(), "application/json".to_string())]),
-            body: crate::json::dumps(&self.0)?,
+            body: crate::json::dumps(&self.0)?.into_bytes(),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use handling::response_handler::handle_response;
 use pyo3::exceptions::PyException;
 use request::Request;
 use response::Response;
-use routing::{delete, get, patch, post, put, static_files, Route, Router};
+use routing::{delete, get, patch, post, put, static_file, Route, Router};
 use status::Status;
 
 use hyper::server::conn::http1;
@@ -193,7 +193,7 @@ fn oxhttp(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(delete, m)?)?;
     m.add_function(wrap_pyfunction!(patch, m)?)?;
     m.add_function(wrap_pyfunction!(put, m)?)?;
-    m.add_function(wrap_pyfunction!(static_files, m)?)?;
+    m.add_function(wrap_pyfunction!(static_file, m)?)?;
 
     Ok(())
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -35,7 +35,7 @@ impl Route {
         }
     }
 
-    pub fn __call__(&self, handler: Py<PyAny>, py: Python<'_>) -> PyResult<Self> {
+    fn __call__(&self, handler: Py<PyAny>, py: Python<'_>) -> PyResult<Self> {
         let inspect = PyModule::import(py, "inspect")?;
         let sig = inspect.call_method("signature", (handler.clone_ref(py),), None)?;
         let parameters = sig.getattr("parameters")?;

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -35,7 +35,7 @@ impl Route {
         }
     }
 
-    fn __call__(&self, handler: Py<PyAny>, py: Python<'_>) -> PyResult<Self> {
+    pub fn __call__(&self, handler: Py<PyAny>, py: Python<'_>) -> PyResult<Self> {
         let inspect = PyModule::import(py, "inspect")?;
         let sig = inspect.call_method("signature", (handler.clone_ref(py),), None)?;
         let parameters = sig.getattr("parameters")?;
@@ -136,28 +136,30 @@ impl Router {
 }
 
 #[pyfunction]
-pub fn static_files(directory: String, path: String, py: Python<'_>) -> PyResult<Route> {
+pub fn static_file(directory: String, path: String, py: Python<'_>) -> PyResult<Route> {
     let pathlib = py.import("pathlib")?;
     let oxhttp = py.import("oxhttp")?;
+    let mimetypes = py.import("mimetypes")?;
 
     let globals = &PyDict::new(py);
     globals.set_item("Path", pathlib.getattr("Path")?)?;
     globals.set_item("directory", directory)?;
     globals.set_item("Status", oxhttp.getattr("Status")?)?;
     globals.set_item("Response", oxhttp.getattr("Response")?)?;
+    globals.set_item("mimetypes", mimetypes)?;
 
-    let handler = py.eval(
+    py.run(
         c_str!(
-            r#"lambda path: \
-                Response(
-                    Status.OK,
-                    open(Path(directory) / path, 'rb')\
-                        .read()\
-                        .decode('utf-8'),
-                    "text/plain",
-                )\
-                if (Path(directory) / path).exists()\
-                else Status.NOT_FOUND"#
+            r#"
+def static_file(path):
+    file_path = f"{directory}/{path}"
+    try:
+        with open(file_path, "rb") as f: content = f.read()
+        content_type, _ = mimetypes.guess_type(file_path)
+        return Response(Status.OK, content, content_type or "application/octet-stream")
+    except FileNotFoundError:
+        return Response(Status.NOT_FOUND, "File not found")
+"#
         ),
         Some(globals),
         None,
@@ -169,6 +171,8 @@ pub fn static_files(directory: String, path: String, py: Python<'_>) -> PyResult
         Some("text/plain".to_string()),
         None,
     );
+
+    let handler = globals.get_item("static_file")?.unwrap();
 
     route.__call__(handler.into(), py)
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -30,7 +30,7 @@ impl IntoResponse for Status {
         Ok(Response {
             status: self.clone(),
             headers: HashMap::from([("Content-Type".to_string(), "text/plain".to_string())]),
-            body: String::new(),
+            body: Vec::new(),
         })
     }
 }


### PR DESCRIPTION
Now, the response is now able to handle bytes from python. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated static file serving to improve error handling and content type detection, ensuring files are delivered reliably.
  - Revised HTTP response generation to consistently handle content as binary data, enhancing delivery across various formats.
  - Adjusted routing methods for clearer endpoint accessibility, supporting smoother overall operations.
  - Renamed functions related to static file handling for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->